### PR TITLE
JNG-6395 Support dash character in model names

### DIFF
--- a/judo-psm-generator-jaxrs-api/src/main/java/hu/blackbelt/judo/psm/generator/jaxrs/api/JavaApiHelper.java
+++ b/judo-psm-generator-jaxrs-api/src/main/java/hu/blackbelt/judo/psm/generator/jaxrs/api/JavaApiHelper.java
@@ -175,10 +175,10 @@ public class JavaApiHelper extends StaticMethodValueResolver {
     }
 
     public static String apiDefaultPathName(Model model) {
-        return StoredVariableHelper.getApiPrefixLocal().replaceAll("\\.", "/" ) + "/" + model.getName().toLowerCase();
+        return StoredVariableHelper.getApiPrefixLocal().replaceAll("\\.", "/" ) + "/" + JavaNamespaceHelper.safeName(model.getName().toLowerCase());
     }
 
     public static String apiDefaultPackageName(Model model) {
-        return StoredVariableHelper.getApiPrefixLocal() + "." + model.getName().toLowerCase();
+        return StoredVariableHelper.getApiPrefixLocal() + "." + JavaNamespaceHelper.safeName(model.getName().toLowerCase());
     }
 }

--- a/judo-psm-generator-jaxrs-api/src/main/java/hu/blackbelt/judo/psm/generator/jaxrs/api/JavaNamespaceHelper.java
+++ b/judo-psm-generator-jaxrs-api/src/main/java/hu/blackbelt/judo/psm/generator/jaxrs/api/JavaNamespaceHelper.java
@@ -52,6 +52,12 @@ public class JavaNamespaceHelper extends StaticMethodValueResolver {
     public static final String DEFAULT_TRANSFER_OBJECT_TYPES = "_default_transferobjecttypes";
 
     public static String safeName(String str) {
+        // Replace any character that is not a valid Java identifier part with '_'
+        // (handles dashes and other separators that may appear in model names).
+        // Preserve '.' so this function is safe to call with dotted FQNs too.
+        if (str != null) {
+            str = str.replaceAll("[^A-Za-z0-9_$.]", "_");
+        }
         if (Arrays.asList(
                 "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
                 "continue", "default", "do", "double", "else", "enum", "exports", "extends",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-6395" title="JNG-6395" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-6395</a>  Model name should be able to contains the dash charachter
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Replace dashes with underscores wherever the model name is used as a Java package or class identifier (OSGi prefixes, default api package, etc.). Maven artifactIds, Docker image names, Karaf feature ids and human-facing strings keep the dashed lowercase form.

JavaNamespaceHelper.safeName now strips non-identifier characters (preserving dots). JavaApiHelper.apiDefaultPackageName / apiDefaultPathName now run the model name through safeName.